### PR TITLE
Check if the request is a type where a cookie can be set

### DIFF
--- a/src/Http/Middleware/ElgentosServersideAnalytics.php
+++ b/src/Http/Middleware/ElgentosServersideAnalytics.php
@@ -25,7 +25,11 @@ class ElgentosServersideAnalytics
 
         $gaUserId = $request->hasCookie('gaUserId') ? $request->cookie('gaUserId') : Str::uuid();
         if (!$request->hasCookie('gaUserId')) {
-            $result = $next($request)->withCookie(cookie()->forever('gaUserId', $gaUserId));
+            $result = $next($request);
+            
+            if(method_exists($result, 'withCookie')) {
+                $result = $result->withCookie(cookie()->forever('gaUserId', $gaUserId));
+            }
         }
 
         config(['frontend.gaUserId' => $gaUserId]);


### PR DESCRIPTION
A response type of `Symfony\Component\HttpFoundation\BinaryFileResponse` for example does not have the `withCookie` function available.